### PR TITLE
💬  Update homepage information

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -5,20 +5,19 @@ layout: base
 <header class="header">
   <div class="row">
     <div class="header-text">
-      <h1>Six days of talks, sprints, and tutorials in San Diego</h1>
+      <h1>Join us for three days of talks and tutorials</h1>
 
       <div class="event-info-detail">
         <strong
-          class="event-info-date">October 17-22, 2021</strong>
+          class="event-info-date">October 21-23, 2021</strong>
 
         <span
           class="subheading event-info-location">
-          San Diego Marriott of Mission Valley in
-          <strong>San Diego, California</strong>
+          <strong>Online</strong>
         </span>
       </div>
 
-      <a class="button" href="{{ site.ticket_link }}">Buy Tickets</a>
+      <a class="button" href="{{ site.cfp_application }}">Submit a Proposal</a>
         <a
           class="button"
           href="http://eepurl.com/bpvu2f">Join Mailing List</a>
@@ -42,7 +41,7 @@ layout: base
       <a href="/tutorials/">
         <div class="dates">
           <div class="month">October</div>
-          <div class="days">17</div>
+          <div class="days">21</div>
         </div>
         <div class="details">
           <h2 class="date-card-title">Tutorials</h2>
@@ -54,23 +53,11 @@ layout: base
       <a href="/talks/">
         <div class="dates">
           <div class="month">October</div>
-          <div class="days">18-20</div>
+          <div class="days">22-23</div>
         </div>
         <div class="details">
           <h2 class="date-card-title">Talks</h2>
-          <p>Dozens of talks chosen by the community</p>
-        </div>
-      </a>
-    </div>
-    <div class="date-card medium-4 column">
-      <a href="/sprints/">
-        <div class="dates">
-          <div class="month">October</div>
-          <div class="days">21-22</div>
-        </div>
-        <div class="details">
-          <h2 class="date-card-title">Sprints</h2>
-          <p>Team up to work on Django!</p>
+          <p>Chosen by the community</p>
         </div>
       </a>
     </div>
@@ -94,26 +81,26 @@ layout: base
     <div class="medium-4 column">
       <div class="card">
         <img
-          src="{{ "/static/img/hands-line.svg" | relative_url }}"
-          alt="Two hands interlocked"
+          src="{{ "/static/img/megaphone.svg" | relative_url }}"
+          alt="Megaphone"
           class="card-icon"
           />
         <div class="card-section">
-          <h3 class="card-title">Thank you!</h3>
-          <p>DjangoCon US 2021 was such a great year. Thanks to our presenters, sponsors, attendees, organizers, volunteers, and everyone who made it so amazing! See you next year!</p>
+          <h3 class="card-title">Submit a proposal!</h3>
+          <p>Please <strong><a href="{{ site.cfp_application }}">submit your proposals today</a></strong>, and encourage people you know to submit! Don’t feel boxed into Django-centric themes; we also love talks about community, web development, user experience, and more.</p>
         </div>
       </div>
     </div>
     <div class="medium-4 column">
       <div class="card">
         <img
-          src="{{ "/static/img/program-line.svg" | relative_url }}"
-          alt="A document with several lines of unreadable text"
+          src="{{ "/static/img/star.svg" | relative_url }}"
+          alt="Star"
           class="card-icon"
           />
         <div class="card-section">
-            <h3 class="card-title">Videos Coming Soon</h3>
-            <p>Check out the <a href="/schedule/">schedule page</a>; we'll post the links to the talk videos on the specific talk pages once the videos are up! </p>
+            <h3 class="card-title">Sponsor DjangoCon</h3>
+            <p>Check out our <strong><a href="/sponsors/information/">sponsorship options</a></strong>! We'd love to have your company join the DjangoCon US team. </p>
         </div>
       </div>
     </div>

--- a/_pages/homepage-default.md
+++ b/_pages/homepage-default.md
@@ -1,10 +1,10 @@
 ---
 layout: home
-title: DjangoCon US 2021 • October 17-22, 2021 • San Diego, CA United States
+title: DjangoCon US 2021 • October 21-23, 2021 • Online
 # permalink: /
 permalink: /homepage/
 description: |
-    Six days of talks, sprints, and tutorials by the community for the community.
+    Three days of inspiration, education, and networking opportunities.
 testimonial_img: /static/img/home-testimonial.jpg
 testimonial_img_mobile: /static/img/home-testimonial-mobile.jpg
 hero_text_align: left


### PR DESCRIPTION
Closes #22 

Changes proposed in this PR:

 - Update location info in header  with the fact that we'll be online
 - Change "buy tickets" link to CFP 
 - Change dates 
 - replace "thank you" with CFP link 
 - replace "videos coming soon" with sponsorship link 