### PR TITLE
🔧 Change class for hamburger menu

### DIFF
--- a/_includes/titlebar.html
+++ b/_includes/titlebar.html
@@ -10,7 +10,7 @@
     </ul>
     <button
       class="hamburger hamburger--spin hide-for-large" type="button" data-toggle="offCanvasRight"
-      aria-hidden="true"
+      aria-haspopup="true"
       aria-label="A button that open and closes site navigation">
       <span class="hamburger-box">
         <span class="hamburger-inner"></span>


### PR DESCRIPTION
This is a start based on https://www.w3.org/TR/wai-aria-practices/examples/menu-button/menu-button-links.html

Closes #47.

Changes proposed in this PR:

- Change the ARIA class of the hamburger menu to indicate that it has a popup

Please add additions as you see fit/know what you're doing.
