### PR TITLE
Create a blog post announcing the talk lineup

### DIFF
--- a/_posts/2021-08-26-announcing-talk-lineup.md
+++ b/_posts/2021-08-26-announcing-talk-lineup.md
@@ -14,7 +14,7 @@ Another huge thank you to our reviewers, without whom this list would still be
 weeks in the making.
 
 We will announce the full conference schedule soon. If you haven't picked up
-your free ticket yet, they're still [available](https://ti.to/defna/djangocon-us-2021).
+your ticket yet, they're still [available](https://ti.to/defna/djangocon-us-2021).
 
 
 - An Introduction to Kubernetes ☸️ by Markus Holtermann ([twitter](https://twitter.com/m_holtermann), [website](https://markusholtermann.eu))
@@ -53,7 +53,7 @@ your free ticket yet, they're still [available](https://ti.to/defna/djangocon-us
 
 Congratulations to all our speakers!
 
-We can't wait to see you at DCUS 2021! Get your [**free** tickets](https://ti.to/defna/djangocon-us-2021)
+We can't wait to see you at DCUS 2021! Get your [free tickets](https://ti.to/defna/djangocon-us-2021)
 today and follow us on [Twitter](https://twitter.com/djangocon) to stay up to
 date on the latest news.
 

--- a/bin/generate_speaker_blog_post.py
+++ b/bin/generate_speaker_blog_post.py
@@ -19,13 +19,13 @@ Another huge thank you to our reviewers, without whom this list would still be
 weeks in the making.
 
 We will announce the full conference schedule soon. If you haven't picked up
-your free ticket yet, they're still [available](https://ti.to/defna/djangocon-us-2021).
+your ticket yet, they're still [available](https://ti.to/defna/djangocon-us-2021).
 """
 
 FOOTER = """
 Congratulations to all our speakers!
 
-We can't wait to see you at DCUS 2021! Get your [**free** tickets](https://ti.to/defna/djangocon-us-2021)
+We can't wait to see you at DCUS 2021! Get your [free tickets](https://ti.to/defna/djangocon-us-2021)
 today and follow us on [Twitter](https://twitter.com/djangocon) to stay up to
 date on the latest news.
 """


### PR DESCRIPTION
Changes proposed in this PR:

- Add a quick, somewhat hacky script to loop over the talks and create a markdown-formatted blog post
- Add the output of that script
