### PR TITLE
🚜  Moves sponsor-levels to _data/*

### DIFF
--- a/_data/sponsor-levels.yml
+++ b/_data/sponsor-levels.yml
@@ -1,0 +1,13 @@
+sponsor-levels:
+  - title: Platinum
+  - title: Speech-to-Text
+  - title: Gold
+  - title: Virtual Conference Hall
+  - title: Invitation
+  - title: Speaker Support
+  - title: Silver
+  - title: Bronze
+  - title: Lanyard
+    hidden: true
+  - title: Diversity & Inclusion
+  - title: Community

--- a/_includes/sponsor-footer.html
+++ b/_includes/sponsor-footer.html
@@ -6,12 +6,11 @@
         <a href="/sponsors/information/" class="button">Become a Sponsor</a>
       </div>
     </div>
-  {% assign sponsors_by_level = "Platinum|Gold|Lanyard|Silver|Bronze|Diversity & Inclusion|Community" | split: "|" %}
-  {% for level in sponsors_by_level %}
-    {% assign sponsors_in_level = site.sponsors | where: 'level', level | where: 'hidden', false %}
+  {% for sponsor-level in site.data.sponsor-levels.sponsor-levels %}
+    {% assign sponsors_in_level = site.sponsors | where: 'level', sponsor-level.title | where: 'hidden', false %}
     {% assign sponsors_count = sponsors_in_level | size %}
     {% if sponsors_count != 0 %}
-    <h4 class="lead min text-center swatch-color-teal">{{ level }}</h4>
+    <h4 class="lead min text-center swatch-color-teal">{{ sponsor-level.title }}</h4>
     <div class="row partner-list">
       {% for sponsor in sponsors_in_level %}
         {% unless sponsor.hidden %}

--- a/_pages/sponsors.html
+++ b/_pages/sponsors.html
@@ -53,32 +53,35 @@ description: DjangoCon US is only possible through the support of various organi
         </div>
 -->
 
-{% assign sponsors_by_level = "Speech-to-Text|Gold|Virtual Conference Hall|Invitation|Speaker Support|Bronze|Diversity & Inclusion|Virtual Conference Hall|Community" | split: "|" %}
-{% for level in sponsors_by_level %}
-  <div class="section-pad {% cycle 'theme-light-gray', 'theme-medium-gray', 'theme-white' %}">
-    <h2 class="text-center v-pad-bottom">{{ level }}</h2>
-    {% for sponsor in site.sponsors %}
-      {% if sponsor.level == level %}
-        {% unless sponsor.hidden %}
-          <div class="row partner">
-            <div class="column medium-4 text-center">
-              <a href="{{ sponsor.url_target }}" rel="sponsored">
-                <img
-                  class="partner-logo {{ sponsor.logo_orientation }}"
-                  src="{{ sponsor.logo }}"
-                  alt="{{ sponsor.name }} Logo" />
-              </a>
+{% for sponsor-level in site.data.sponsor-levels.sponsor-levels %}
+  {% assign sponsors_in_level = site.sponsors | where: 'level', sponsor-level.title | where: 'hidden', false %}
+  {% assign sponsors_count = sponsors_in_level | size %}
+  {% if sponsors_count != 0 %}
+    <div class="section-pad {% cycle 'theme-light-gray', 'theme-medium-gray', 'theme-white' %}">
+      <h2 class="text-center v-pad-bottom">{{ sponsor-level.title }}</h2>
+      {% for sponsor in sponsors_in_level %}
+        {% if sponsor.level == sponsor-level.title %}
+          {% unless sponsor.hidden %}
+            <div class="row partner">
+              <div class="column medium-4 text-center">
+                <a href="{{ sponsor.url_target }}" rel="sponsored">
+                  <img
+                    class="partner-logo {{ sponsor.logo_orientation }}"
+                    src="{{ sponsor.logo }}"
+                    alt="{{ sponsor.name }} Logo" />
+                </a>
+              </div>
+              <div class="column medium-8">
+                <h3 class="partner-name"><a href="{{ sponsor.url_target }}" rel="sponsored">{{ sponsor.name }}</a></h3>
+                {% capture sponsor_description %}{{ sponsor.description }}{: .partner-description }{% endcapture %}
+                {{ sponsor_description | markdownify }}
+                {% if sponsor.hiring %}<a href="/jobs/" class="button">{{ sponsor.name }} is hiring!</a>{% endif %}
+              </div>
             </div>
-            <div class="column medium-8">
-              <h3 class="partner-name"><a href="{{ sponsor.url_target }}" rel="sponsored">{{ sponsor.name }}</a></h3>
-              {% capture sponsor_description %}{{ sponsor.description }}{: .partner-description }{% endcapture %}
-              {{ sponsor_description | markdownify }}
-              {% if sponsor.hiring %}<a href="/jobs/" class="button">{{ sponsor.name }} is hiring!</a>{% endif %}
-            </div>
-          </div>
-        {% endunless %}
-      {% endif %}
-    {% endfor %}
+          {% endunless %}
+        {% endif %}
+      {% endfor %}
     </div>
-  {% endfor %}
+  {% endif %}
+{% endfor %}
 </div>


### PR DESCRIPTION
This is an attempt to make sponsor's level easier to display both on the homepage footer and the sponsor's page. 

- Adds `_data/sponsor-levels.yml`
- Only displays sponsors if they exist for a give level/plan
- Order sponsor levels by the order that is in `_data/sponsor-levels.yml`
- Add the ability to `hidden: true` anything that we don't want to show up