### PR TITLE
Add talk page in English

### DIFF
--- a/_schedule/talks/2021-10-22-15-32-maintaining-demystified.md
+++ b/_schedule/talks/2021-10-22-15-32-maintaining-demystified.md
@@ -1,0 +1,51 @@
+---
+abstract: Many Djangonauts suddenly find themselves maintaining a project. I’ll use my years of experience as a professional open source maintainer to teach you the essential process and best practices of being a maintainer. Not only is maintaining a step change in knowledge, it can be fun too!
+accepted: true
+category: talks
+date: 2021-10-22 15:32:00 -0500
+difficulty: Beginner
+image: /static/img/social/presenters/katherine-michel.png
+layout: session-details
+permalink: /talks/maintaining-demystified/
+presenter_slugs:
+- katherine-michel
+presenters:
+- bio: "Kati is a web developer, open source maintainer, and technical writer. Her
+    recent clients include The Wharton School and Eldarion. She has also been the
+    DjangoCon US Website Chair and Co-Chair. In her free time, she enjoys traveling,
+    eating good food, and listening to music. \r\n"
+  company: DEFNA, DjangoCon US Website Chair
+  github: ''
+  name: Katherine Michel
+  photo_url: ''
+  twitter: KatiMichel
+  website: https://github.com/KatherineMichel
+published: true
+sitemap: true
+slides_url: ''
+summary: ''
+tags: []
+talk_slot: full
+title: Maintaining Demystified
+video_url: 'https://youtu.be/56sxu9vEJNc'
+additional_video_url: 'https://youtu.be/BKJKAN2kEM8'
+---
+
+You’ll learn
+
+* How to set a project up for long-term success
+* Which community health files you need
+* The general license types, how to choose one, and special considerations
+* How to keep your code secure
+* Best practices for onboarding contributors
+* The importance of documentation and strategies for managing it
+* A typical pull request review process
+* Python/Django specific matrix testing, code quality, and packaging tools
+* How to keep code up to date through release management
+* Which GitHub features might be most useful
+* Project management strategies
+* How to measure the health of your project
+* The importance of publicizing your project
+* Strategies for managing the work as you scale
+* Some thoughts on people management and mentoring
+* Tips for getting started as a maintainer


### PR DESCRIPTION
Changes proposed in this PR:

- I figured it would be useful to add the talk page in English, since that recording will be available
- Presumably the additional URL in the Spanish page was for the English version, so I switched them in this page.
