### PR TITLE
⏱ Update the time for Kati's talks

### DIFF
--- a/_schedule/talks/2021-10-22-15-30-desmitificando-el-mantenimiento.md
+++ b/_schedule/talks/2021-10-22-15-30-desmitificando-el-mantenimiento.md
@@ -6,7 +6,7 @@ abstract: Muchos Djangonautas de repente tienen la necesidad de mantener un proy
 accepted: true
 additional_video_url: https://youtu.be/56sxu9vEJNc
 category: talks
-date: 2021-10-22 15:32:00 -0500
+date: 2021-10-22 15:30:00 -0500
 difficulty: Beginner
 image: /static/img/social/presenters/katherine-michel.png
 layout: session-details

--- a/_schedule/talks/2021-10-22-15-30-maintaining-demystified.md
+++ b/_schedule/talks/2021-10-22-15-30-maintaining-demystified.md
@@ -6,7 +6,7 @@ abstract: Many Djangonauts suddenly find themselves maintaining a project. I’l
 accepted: true
 additional_video_url: https://youtu.be/BKJKAN2kEM8
 category: talks
-date: 2021-10-22 15:32:00 -0500
+date: 2021-10-22 15:30:00 -0500
 difficulty: Beginner
 image: /static/img/social/presenters/katherine-michel.png
 layout: session-details


### PR DESCRIPTION
My script missed the title rename (and it would've missed the English
version anyway)

Changes proposed in this PR:

- Changes the start time for @KatherineMichel's talk to 3:30 CDT
