### PR TITLE
JS for #a11y of menu?

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,64 +1,33 @@
 <li><a href="{{ site.ticket_link }}">Tickets</a></li>
 <li><a href="/talks/">Talk Schedule</a></li>
-<!-- <li><a href="/tickets/">Tickets</a></li> -->
-<!--<li class="is-dropdown-submenu-parent">
-  <a href="/schedule/">Schedule</a>
-  <ul class="menu vertical nested">
-    <li><a href="/schedule/">Full Schedule</a></li>
-    <li><a href="/tutorials/">Tutorials Schedule</a></li>
-    <li><a href="/talks/">Talks Schedule</a></li>
-    <li><a href="/sprints/">Sprints Schedule</a></li>
-  </ul>
-</li>-->
-<!--<li class="is-dropdown-submenu-parent">
-  <a href="/venue/">Venue</a>
-  <ul class="menu vertical nested">
-    <li><a href="/venue/#welcome">Welcome to San Diego!</a></li>
-    <li><a href="/venue/#hotel">Staying at San Diego Marriott</a></li>
-    <li><a href="/venue/#places">Around San Diego</a></li>
-    <li><a href="/venue/#accessibility">Accessibility</a></li>
-    <li><a href="/room-sharing/">Room Sharing</a></li>
-  </ul>
-</li>-->
-<!--<li class="is-dropdown-submenu-parent">
-  <a href="/speaking/">Speaking</a>
-  <ul class="menu vertical nested">
-    <li><a href="/speaking/">Speaking at DjangoCon US</a></li>
-    <li><a href="/speaking/speaker-resources/">Speaker Resources</a></li>
-  </ul>
-</li>-->
-<!--<li><a href="/sponsors/information/">Become a Sponsor</a></li>-->
 <li><a href="/news/">News</a></li>
 <li><a href="/chat/">Chat</a></li>
 <li><a href="/jobs/">Jobs Board</a></li>
 <li><a href="/sponsors/">Sponsors</a></li>
-{% comment %}
-<li class="is-dropdown-submenu-parent">
-  <ul class="menu vertical nested">
-    <li><a href="/sponsors/">Our Sponsors</a></li>
-    <li><a href="/sponsors/information/">Become a Sponsor</a></li>
-  </ul>
-</li>
-{% endcomment %}
 <li><a href="/jobs/">Jobs Board</a></li>
-<!--<li><a href="/opportunity-grants/">Opportunity Grants</a></li>-->
 <li class="is-dropdown-submenu-parent">
-  <a href="/about/">About</a>
+  <a href="/about/" aria-haspopup="true" aria-expanded="false">About</a>
   <ul class="menu vertical nested">
     <li><a href="/about/">About DjangoCon US</a></li>
-    <!--<li><a href="/tickets/">Tickets</a></li>-->
-    <!--<li><a href="/faq/">FAQ</a></li>-->
     <li><a href="/conduct/">Code of Conduct</a></li>
-    <!--<li><a href="/opportunity-grants/">Opportunity Grants</a></li>-->
-    <!--<li><a href="/why-djangocon-us/">Why DjangoCon US?</a></li>-->
     <li><a href="/organizers/">Organizers</a></li>
     <li><a href="/speaking/">Speaking</a></li>
   </ul>
 </li>
-{% comment %}
-<li>
-  <a href="{{ site.ticket_link }}" class="button hollow">
-    Buy Tickets
-  </a>
-</li>
-{% endcomment %}
+
+<script type="text/javascript">
+  var menuItems = document.querySelectorAll('li.is-dropdown-submenu-parent');
+  Array.prototype.forEach.call(menuItems, function(el, i){
+    el.querySelector('a').addEventListener("click",  function(event){
+      if (this.parentNode.className == "has-submenu") {
+        this.parentNode.className = "has-submenu open";
+        this.setAttribute('aria-expanded', "true");
+      } else {
+        this.parentNode.className = "has-submenu";
+        this.setAttribute('aria-expanded', "false");
+      }
+      event.preventDefault();
+      return false;
+    });
+  });
+</script>


### PR DESCRIPTION
Improves upon #47 .

Changes proposed in this PR:

- Add some classes and inline JS to make the menu for Aria-compliant

In testing with the VoiceOver app, this seems to work with standard keyboard actions (tab, enter, escape). You can tab over to the About menu, click Enter, then tab through the links in the About menu and click Enter to navigate to those pages. If you click esc when you're in the About menu, the cursor returns to the first item in the navbar (which is not ideal, I know, but I can't figure out how to fix that). I can try to spend some more time on it next week, but I believe this represents progress. 
