### PR TITLE
Remove extra jobs board link

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -2,7 +2,6 @@
 <li><a href="/talks/">Talk Schedule</a></li>
 <li><a href="/news/">News</a></li>
 <li><a href="/chat/">Chat</a></li>
-<li><a href="/jobs/">Jobs Board</a></li>
 <li><a href="/sponsors/">Sponsors</a></li>
 <li><a href="/jobs/">Jobs Board</a></li>
 <li class="is-dropdown-submenu-parent">


### PR DESCRIPTION
Changes proposed in this PR:

- We've got an extra jobs board link on the navbar.
-
