### PR TITLE
:alarm_clock: Change the start time of Friday social hour

### DIFF
--- a/_schedule/talks/2021-10-22-18-15-social-hour.md
+++ b/_schedule/talks/2021-10-22-18-15-social-hour.md
@@ -1,7 +1,7 @@
 ---
 accepted: true
 category: social-hour
-date: 2021-10-22 18:25:00 -0500
+date: 2021-10-22 18:15:00 -0500
 difficulty: null
 layout: session-details
 permalink: /talks/social-hour-friday/


### PR DESCRIPTION
I had 10 minutes booked in the schedule for thanking volunteers.

That got rolled into the intro, so this block is not needed.