### PR TITLE
Fix alt text for presenters’ photos

### DIFF
--- a/_includes/schedule-session-full.html
+++ b/_includes/schedule-session-full.html
@@ -33,7 +33,7 @@
         <img
           class="avatar"
           src="{{ presenter.photo_url }}"
-          alt="Photo of {{ presenter.presenters }}" />
+          alt="Photo of {{ presenter.name }}" />
         {% endif %}
         {{ presenter.name }}
         {% if presenter.pronouns != blank %}

--- a/_includes/schedule-session.html
+++ b/_includes/schedule-session.html
@@ -38,7 +38,7 @@
           <img
             class="avatar"
             src="{{ presenter.photo_url }}"
-            alt="Photo of {{ presenter.presenters }}" />
+            alt="Photo of {{ presenter.name }}" />
           {% endif %}
           {{ presenter.name }}
           {% if presenter.pronouns != blank %}

--- a/_layouts/session-details.html
+++ b/_layouts/session-details.html
@@ -91,7 +91,7 @@ layout: base
           <img
             class="thumbnail"
             src="{{ presenter.photo_url }}"
-            alt="Photo of {{ presenter.presenters }}" />
+            alt="Photo of {{ presenter.name }}" />
         {% endif %}
       </div>
 


### PR DESCRIPTION
The `{{ presenter.presenters }}` attribute doesn’t output anything, so at the moment all of those images have the same alt text of `Photo of`.  This switches to `name` so each image has unique alt text.